### PR TITLE
Feature/message manager support max

### DIFF
--- a/ImpPager.class.nut
+++ b/ImpPager.class.nut
@@ -75,7 +75,8 @@ class ImpPager {
     }
 
     function _onFail(message, reason, retry) {
-        _log_debug("Failed to deliver message name: '" + message.name + "', data: " + message.data + ", error: " + reason);
+        local payload = message.payload
+        _log_debug("Failed to deliver message name: '" + payload.name + "', data: " + payload.data + ", error: " + reason);
         // On fail write the message to the SPI Flash for further processing
         // only if it's not already there.
         if (!("metadata" in message) || !("addr" in message.metadata) || !(message.metadata.addr)) {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2015 TheThings.IO
+Copyright 2016-2017 Electric Imp
+
+SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +11,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,88 +1,33 @@
-# ImpPager
+# ReplayMessenger
 
-The Library for reliable and resilient communication between imp devices and virtual imp agents. It wraps [ConnectionManager](https://github.com/electricimp/connectionmanager/tree/v1.0.1), [Bullwinkle](https://github.com/electricimp/Bullwinkle#bullwinklepackage) and [SpiFlashLogger](https://github.com/electricimp/SpiFlashLogger) libraries.
+The Library for reliable and resilient communication between imp devices and virtual 
+imp agents. It wraps 
+[ConnectionManager](https://github.com/electricimp/connectionmanager/tree/v1.0.1), 
+[MessageManager](https://github.com/electricimp/MessageManager) and 
+[SpiFlashLogger](https://github.com/electricimp/SpiFlashLogger) libraries.
 
-**To add this library to your project, copy and paste the source code to the top of your device code.**
+**To add this library to your project, add** 
+`#require "ReplayMessenger.device.lib.nut:1.0.0"` 
+**to the top of your device code.**
 
-## Class ImpPager.ConnectionManager
-
-Extends [ConnectionManager](https://github.com/electricimp/connectionmanager/tree/v1.0.1) and overrides onConnect/onDisconnect methods to allow for multiple connect/disconnect handlers to be registered. 
-
-**ImpPager.ConnectionManager should be used instead of [ConnectionManager](https://github.com/electricimp/connectionmanager/tree/v1.0.1). Only a single instance of the class can be created per application.**
-
-### Class Usage
-
-#### Constructor: ImpPager.ConnectionManager(*[settings]*)
-
-The ConnectionManager class can be instantiated with an optional table of settings that modify its behavior. The following settings are available:
-
-| key               | default             | notes |
-| ----------------- | ------------------- | ----- |
-| startDisconnected | `false`             | When set to `true` the device immediately disconnects |
-| stayConnected     | `false`             | When set to `true` the device will aggressively attempt to reconnect when disconnected |
-| blinkupBehavior   | BLINK_ON_DISCONNECT | See below |
-| checkTimeout      | 5                   | Changes how often the ConnectionManager checks the connection state (online / offline). |
-| sendTimeout       | 1                   | Timeout for server.setsendtimeoutpolicy. It's recommended that the timeout is a nonzero value, but still small. This will help to avoid TCP buffer overflow and accidental device disconnect issues. |
-| sendBufferSize    | 8096                | The value passed to the imp.setsendbuffersize. **NOTE: We've found setting the buffer size to 8096 to be very helpful in many applications using the ConnectionManager class, though your application may require a different buffer size.** |
-
-```squirrel
-cm <- ImpPager.ConnectionManager({
-    "blinkupBehavior"  : ConnectionManager.BLINK_ALWAYS,
-    "stayConnected"    : true,
-    "sendTimeout"      : 1,
-    "sendBufferSeze"   : 8096
-});
-
-```
-
-### Class Methods
-
-#### onDisconnect(callback)
-
-The *onDisconnect* method adds a callback method to the onDisconnect event. The onDisconnect event will fire every time the connection state changes from online to offline, or when the ConnectionManager's *disconnect* method is called (even if the device is already disconnected).
-
-*The callback method takes a single parameter - `expected` - which is `true`when the onDisconnect event fired due to the ConnectionManager's disconnect method being called, and `false` otherwise (an unexpected state change from connected to disconnected).*
-
-```squirrel
-cm.onDisconnect(function(expected) {
-    if (expected) {
-        // log a regular message that we disconnected as expected
-        cm.log("Expected Disconnect");
-    } else {
-        // log an error message that we unexpectedly disconnected
-        cm.error("Unexpected Disconnect");
-    }
-});
-```
-
-**NOTE: a callback is added as a weak reference to the function.**
-
-#### onConnect(callback)
-
-The *onConnect* method adds a callback method to the onConnect event. The onConnect event will fire every time the connection state changes from offline to online, or when the ConnectionManager's *connect* method is called (even if the device is already connected).
-
-*The callback method takes zero parameters.*
-
-```squirrel
-cm.onConnect(function() {
-    // Send a message to the agent indicating that we're online
-    agent.send("online", true);
-});
-```
-
-**NOTE: a callback is added as a weak reference to the function.**
-
-## Class ImpPager
+## Class ReplayMessenger
 
 The main library class. There may be multiple instances of the class created by application.
 
-### Constructor: ImpPager(*connectionManager, [bullwinkle], [spiFlashLogger], [debug]*)
+### Constructor: ReplayMessenger(*options*)
 
-Accepts two optional arguments:
-- connectionManager - instance of ImpPager.ConnectionManager class that extends [ConnectionManager](https://github.com/electricimp/connectionmanager/tree/v1.0.1).
-- bullwinkle - instance of [Bullwinkle](https://github.com/electricimp/Bullwinkle#bullwinklepackage). If null or not specified, is created by the ImpPager constructor with "messageTimeout" set to IMP_PAGER_MESSAGE_TIMEOUT (=1).
-- spiFlashLogger - instance of [SpiFlashLogger](https://github.com/electricimp/SpiFlashLogger)
-- debug - the flag that controls library debug output. Defaults to false.
+Calling the ReplayMessenger constructor creates a new ReplayMessenger instance. 
+An optional table can be passed into the constructor (as *options*) to override 
+default behaviours. *options* can contain any of the following keys:
+
+| Key | Data Type | Default Value | Description |
+| ----- | -------------- | ------------------ | --------------- |
+| *debug* | Boolean | `false` | The flag that enables debug library mode, which turns on extended logging |
+| *retryInterval* | Integer | 0 | Changes the default timeout parameter passed to the [retry](#mmanager_retry) method |
+| *messageTimeout* | Integer | 10 | Changes the default timeout required before a message is considered failed (to be acknowledged or replied to) |
+| *connectionManager* | [ConnectionManager](https://github.com/electricimp/ConnectionManager) | `null` | Optional instance of the [ConnectionManager](https://github.com/electricimp/ConnectionManager) library that helps ReplayManager to track the connectivity status |
+| *MessageManager* | [MessageManager](https://github.com/electricimp/ConnectionManager) | `null` | Optional instance of the [MessageManager](https://github.com/electricimp/MessageManager) library that helps ReplayManager to exchange data between device and agent |
+| *spiFlashLogger* | [SPIFlashLogger](https://github.com/electricimp/ConnectionManager) | `null` | Optional instance or array of instances of the [SPIFlashLogger](https://github.com/electricimp/SPIFlashLogger) library that helps ReplayManager to persist some messenger on a flash or a memory |
 
 
 ```squirrel

--- a/ReplayMessenger.class.nut
+++ b/ReplayMessenger.class.nut
@@ -34,7 +34,10 @@ class ReplayMessenger {
     constructor(options = {}) {
 
         _cm            = "connectionManager" in options ? options["connectionManager"] : ConnectionManager();
-        _mm            = "messageManager"    in options ? options["messageManager"]    : MessageManager({"messageTimeout" : REPLAY_MESSENGER_MESSAGE_TIMEOUT_SEC});
+        _mm            = "messageManager"    in options ? options["messageManager"]    : MessageManager({
+            "messageTimeout"    : REPLAY_MESSENGER_MESSAGE_TIMEOUT_SEC,
+            "connectionManager" : _cm
+        });
         _spiFL         = "spiFlashLogger"    in options ? options["spiFlashLogger"]    : SPIFlashLogger();
         _retryInterval = "retryInterval"     in options ? options["retryInterval"]     : REPLAY_MESSENGER_RETRY_INTERVAL_SEC;
         _debug         = "debug"             in options ? options["debug"]             : debug;
@@ -106,8 +109,8 @@ class ReplayMessenger {
                 _log("Resending message name: '" + savedMsg.name + "', data: " + savedMsg.data);
                 send(savedMsg.name, savedMsg.data, {"addr" : addr});
 
-                // Don't do any further scanning until we get an ACK for the already sent message
-                next(false);
+                // Skip to next item
+                next();
             }.bindenv(this),
             function() {
                 _log("Finished processing all pending messages");

--- a/ReplayMessenger.class.nut
+++ b/ReplayMessenger.class.nut
@@ -71,7 +71,7 @@ class ReplayMessenger {
         _log("ACKed message name: '" + message.payload.name + "', data: " + message.payload.data);
         if ("metadata" in message && "addr" in message.metadata && message.metadata.addr) {
             local addr = message.metadata.addr;
-            _log("Erasing object at addreess: " + addr);
+            _log("Erasing object at address: " + addr);
             _spiFL.erase(addr);
             message.metadata.addr = null;
             _scheduleRetryIfConnected();

--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -24,7 +24,7 @@
 
 
 const RM_TCP_ACK_TIMEOUT_SEC = 30;
-const RM_DEFAULT_MESSAGE_TIMEOUT_SEC = 5;
+const RM_DEFAULT_MESSAGE_TIMEOUT_SEC = 10;
 const RM_DEFAULT_RETRY_INTERVAL_SEC  = 0.5;
 
 class ReplayMessenger {
@@ -59,8 +59,8 @@ class ReplayMessenger {
             "ackTimeout" : RM_TCP_ACK_TIMEOUT_SEC
         });
         _mm = "messageManager" in options ? options["messageManager"] : MessageManager({
-              "messageTimeout"    : RM_DEFAULT_MESSAGE_TIMEOUT_SEC,
-              "connectionManager" : _cm
+            "messageTimeout"    : RM_DEFAULT_MESSAGE_TIMEOUT_SEC,
+            "connectionManager" : _cm
         });
         _debug = "debug" in options ? options["debug"] : debug;
         _retryInterval = "retryInterval" in options ? options["retryInterval"] : RM_DEFAULT_RETRY_INTERVAL_SEC;
@@ -108,7 +108,6 @@ class ReplayMessenger {
     }
 
     function _onAck(message) {
-        // Do nothing
         _log("ACKed message name: '" + message.payload.name + "', data: " + message.payload.data);
         if ("addr" in message.metadata && message.metadata.addr) {
             local addr = message.metadata.addr;

--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -1,7 +1,29 @@
-// Copyright (c) 2016-2017 Electric Imp
-// This file is licensed under the MIT License
-// http://opensource.org/licenses/MIT
+// MIT License
+//
+// Copyright 2016-2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
 
+
+const RM_TCP_ACK_TIMEOUT_SEC = 30;
 const RM_DEFAULT_MESSAGE_TIMEOUT_SEC = 5;
 const RM_DEFAULT_RETRY_INTERVAL_SEC  = 0.5;
 
@@ -33,7 +55,9 @@ class ReplayMessenger {
 
     constructor(options = {}) {
 
-        _cm            = "connectionManager" in options ? options["connectionManager"] : ConnectionManager();
+        _cm            = "connectionManager" in options ? options["connectionManager"] : ConnectionManager({
+            "ackTimeout" : RM_TCP_ACK_TIMEOUT_SEC
+        });
         _mm            = "messageManager"    in options ? options["messageManager"]    : MessageManager({
             "messageTimeout"    : RM_DEFAULT_MESSAGE_TIMEOUT_SEC,
             "connectionManager" : _cm
@@ -50,9 +74,6 @@ class ReplayMessenger {
         _cm.onConnect(_onConnect.bindenv(this));
         _cm.onDisconnect(_onDisconnect.bindenv(this));
 
-        // _spiFL.eraseAll(true);
-        // return;
-
         // Schedule routine to retry sending messages
         _scheduleRetryIfConnected();
     }
@@ -67,6 +88,10 @@ class ReplayMessenger {
 
     function onDisconnect(callback) {
         _onDiscHandler = callback;
+    }
+
+    function eraseAll() {
+        _spiFL.eraseAll(true);
     }
 
     function _onAck(message) {

--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -84,7 +84,6 @@ class ReplayMessenger {
 
     function send(messageName, data = null, loggerName = "default", metadata = null) {
         if (!(loggerName in _spiFL)) {
-            server.log(loggerName);
             throw format("Logger \"%s\" does not exist", loggerName);
         }
         if (metadata == null) {

--- a/tests/agent-handler.nut
+++ b/tests/agent-handler.nut
@@ -1,0 +1,60 @@
+// MIT License
+//
+// Copyright 2016-2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+
+@include "https://raw.githubusercontent.com/electricimp/MessageManager/develop/MessageManager.lib.nut"
+
+// @include "github:electricimp/MessageManager/MessageManager.lib.nut@develop"
+
+const MSG_COUNT = 100;
+const DATA_MSG_NAME  = "data";
+const INIT_MSG_NAME  = "init";
+const ERROR_MSG_NAME = "errors";
+
+local mm = MessageManager()
+
+local totalCount = 0
+local received = array(MSG_COUNT, 0)
+
+mm.on(INIT_MSG_NAME, function(msg, reply) {
+    totalCount = msg.data;
+    received = array(totalCount, 0);
+})
+
+mm.on(DATA_MSG_NAME, function(msg, reply) {
+    // server.log("message received: " + msg.data);
+    received[msg.data] += 1;
+})
+
+mm.on(ERROR_MSG_NAME, function(data, reply) {
+    local errorCount = 0
+    for (local i = 0; i < totalCount; i++) {
+        if (received[i] == 0) {
+            server.log("  !!! " + i + ": " + received[i]);
+            errorCount++;
+        }
+    }
+    // server.log("Error count: " + errorCount);
+    reply(errorCount);
+})

--- a/tests/basic.device.test.nut
+++ b/tests/basic.device.test.nut
@@ -1,0 +1,139 @@
+// MIT License
+//
+// Copyright 2016-2017 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+
+@include "https://raw.githubusercontent.com/electricimp/ConnectionManager/master/ConnectionManager.class.nut"
+@include "https://raw.githubusercontent.com/electricimp/SpiFlashLogger/master/SPIFlashLogger.class.nut"
+@include "https://raw.githubusercontent.com/electricimp/Serializer/develop/Serializer.class.nut"
+@include "https://raw.githubusercontent.com/electricimp/MessageManager/develop/MessageManager.lib.nut"
+
+// @include "github:electricimp/ConnectionManager/ConnectionManager.class.nut"
+// @include "github:electricimp/SPIFlashLogger/SPIFlashLogger.class.nut"
+// @include "github:electricimp/Serializer/Serializer.class.nut"
+// @include "github:electricimp/MessageManager/MessageManager.lib.nut@develop"
+
+class BasicTests extends ImpTestCase {
+
+    static MSG_COUNT = 100;
+    static DATA_MSG_NAME  = "data";
+    static INIT_MSG_NAME  = "init";
+    static ERROR_MSG_NAME = "errors";
+
+    _cm = null;
+    _mm = null;
+    _rm = null;
+    _errors = null;
+
+    _ConnectionManager = class {
+        _errors = 0;
+        _onConnect    = null;
+        _isConnected  = null;
+        _onDisconnect = null;
+
+        constructor() {
+            _isConnected = true;
+        }
+
+        function isConnected() {
+            return _isConnected;
+        }
+
+        function log(str) {
+            server.log(str);
+        }
+
+        function connect() {
+            _isConnected = true;
+            _onConnect && _onConnect();
+        }
+
+        function disconnect() {
+            _isConnected = false;
+            _onDisconnect && _onDisconnect(true);
+        }
+
+        function onConnect(callback) {
+            _onConnect = callback;
+        }
+
+        function onDisconnect(callback) {
+            _onDisconnect = callback;
+        }
+    }
+
+    function setUp() {
+        // Create ConnectionManager
+        _cm = _ConnectionManager();
+
+        // Create MessageManager
+        local mmOptions = {
+            "connectionManager" : _cm
+        };
+        _mm = MessageManager(mmOptions);
+        _mm.onReply(function(msg, response) {
+            _errors = response;
+        }.bindenv(this));
+
+        // Create ReplayMessenger
+        local rmOptions = {
+            "connectionManager" : _cm,
+            "messageManager"    : _mm,
+            "retryInterval"     : 1,
+            "debug"             : false
+        }
+        _rm = ReplayMessenger(rmOptions);
+        _rm.eraseAll();
+
+        _rm.send(INIT_MSG_NAME, MSG_COUNT);
+    }
+
+    function testTempDisconnect() {
+        local disconnectAt = MSG_COUNT / 4;
+        local connectAt = MSG_COUNT - disconnectAt;
+
+        for (local i = 0; i < MSG_COUNT; i++) {
+            if (i == disconnectAt) {
+                _cm.disconnect();
+            }
+
+            if (i == connectAt) {
+                _cm.connect();
+            }
+
+            _rm.send(DATA_MSG_NAME, i);
+        }
+
+        _rm.send(ERROR_MSG_NAME, null);
+
+        return Promise(function(resolve, reject) {
+            imp.wakeup(20, function() {
+                assertEqual(0, _errors, "# of errors: " + _errors);
+                resolve();
+            }.bindenv(this))
+        }.bindenv(this))
+    }
+
+    function tearDown() {
+    }
+}


### PR DESCRIPTION
- Added “_readOptions” table that allows a user to define the step/skip
parameters for SPIFlashLogger.read method
- Added onReplayBegin/Complete handlers that allow a user to define
middleware for what happens when replaying data begins and is completed
- Added support for “retryOnInit” option that allowed a user to delay
calling “_scheduleRetryIfConnected” (in case there are several messages
that need to be sent on init — this can be memory intensive)
- Modified _onAck and _onFail so that it only catches messages that
have “loggerName” in the metadata — this assumes that this key being
present means that it was sent through RM (a better option may be to
just use the per-message onAck/onFail handlers)
- Include message metadata in what is saved to SPIFlash — don’t assume
that a user hasn’t included something important here